### PR TITLE
Refactor/remove networkmanager

### DIFF
--- a/cli/examine.sh
+++ b/cli/examine.sh
@@ -111,21 +111,21 @@ if [[ -s "$DEVICE_LIST_NETWORK" ]]; then
         #get DEVICE and TYPE (ports 1 and 2)
         DEVICE_1=$($CLI_PATH/get/get_nic_config $i 1 DEVICE)
         if [ ! "$DEVICE_1" = "" ]; then
-          TYPE_1=$($CLI_PATH/get/get_nic_config $i 1 TYPE)
+          #TYPE_1=$($CLI_PATH/get/get_nic_config $i 1 TYPE)
+          TYPE_1="(ethernet)"
           XDP_1=$($CLI_PATH/get/get_nic_config $i 1 XDP)
           if [ ! "$XDP_1" = "" ]; then
-            TYPE_1="ethxdp"
+            TYPE_1="(ethxdp)"
           fi
-          TYPE_1="($TYPE_1)"
         fi
         DEVICE_2=$($CLI_PATH/get/get_nic_config $i 2 DEVICE)
         if [ ! "$DEVICE_2" = "" ]; then
-          TYPE_2=$($CLI_PATH/get/get_nic_config $i 2 TYPE)
+          #TYPE_2=$($CLI_PATH/get/get_nic_config $i 2 TYPE)
+          TYPE_2="(ethernet)"
           XDP_2=$($CLI_PATH/get/get_nic_config $i 2 XDP)
           if [ ! "$XDP_2" = "" ]; then
-            TYPE_2="ethxdp"
+            TYPE_2="(ethxdp)"
           fi
-          TYPE_2="($TYPE_2)"
         fi
         #print row
         echo "$id            : $bdf : $device_type_name : $add_0 : $DEVICE_1 $TYPE_1"

--- a/cli/get/get_nic_config.sh
+++ b/cli/get/get_nic_config.sh
@@ -73,22 +73,28 @@ case "$parameter" in
       fi
       ;;
     STATE)
-      if [ ! "$iface" = "" ]; then
-        STATE=$(nmcli dev | grep "$iface" | awk '{print $3}')
-        echo $STATE
-      fi
+      echo "Deprecated option (get_nic_config): $parameter"
+      exit 1
+      #if [ ! "$iface" = "" ]; then
+      #  STATE=$(nmcli dev | grep "$iface" | awk '{print $3}')
+      #  echo $STATE
+      #fi
       ;;
     CONNECTION)
-      if [ ! "$iface" = "" ]; then
-        CONNECTION=$(nmcli dev | grep "$iface" | awk '{print $4}')
-        echo $SCONNECTIONTATE
-      fi
+      echo "Deprecated option (get_nic_config): $parameter"
+      exit 1
+      #if [ ! "$iface" = "" ]; then
+      #  CONNECTION=$(nmcli dev | grep "$iface" | awk '{print $4}')
+      #  echo $SCONNECTIONTATE
+      #fi
       ;;
     TYPE)
-      if [ ! "$iface" = "" ]; then
-        TYPE=$(nmcli dev | grep "$iface" | awk '{print $2}')
-        echo $TYPE
-      fi
+      echo "Deprecated option (get_nic_config): $parameter"
+      exit 1
+      #if [ ! "$iface" = "" ]; then
+      #  TYPE=$(nmcli dev | grep "$iface" | awk '{print $2}')
+      #  echo $TYPE
+      #fi
       ;;
     XDP)
       if [ ! "$iface" = "" ]; then

--- a/login/login_build.sh
+++ b/login/login_build.sh
@@ -112,7 +112,7 @@ cd
 while read -r line || [[ -n "$line" ]]; do
   # Extract all MAC addresses from the line
   # Match typical MAC patterns: xx:xx:xx:xx:xx:xx
-  macs=$(echo "$line" | grep -oE '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}')
+  macs=$(echo "$line" | grep -oE '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}' | awk '{print tolower($0)}')
 
   for mac in $macs; do
     # Find interface for this MAC

--- a/login/login_deployment.sh
+++ b/login/login_deployment.sh
@@ -349,7 +349,7 @@ done
 while read -r line || [[ -n "$line" ]]; do
   # Extract all MAC addresses from the line
   # Match typical MAC patterns: xx:xx:xx:xx:xx:xx
-  macs=$(echo "$line" | grep -oE '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}')
+  macs=$(echo "$line" | grep -oE '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}' | awk '{print tolower($0)}')
 
   for mac in $macs; do
     # Find interface for this MAC

--- a/login/login_deployment.sh
+++ b/login/login_deployment.sh
@@ -346,10 +346,29 @@ do
 done
 
 #set MTU on Mellanox interface
-mellanox_name=$(nmcli dev | grep mellanox-0 | awk '{print $1}')
-if [[ -n "$mellanox_name" ]]; then
-	sudo ifconfig $mellanox_name mtu $MTU_DEFAULT up
-fi
+while read -r line || [[ -n "$line" ]]; do
+  # Extract all MAC addresses from the line
+  # Match typical MAC patterns: xx:xx:xx:xx:xx:xx
+  macs=$(echo "$line" | grep -oE '([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}')
+
+  for mac in $macs; do
+    # Find interface for this MAC
+    iface=$(for i in /sys/class/net/*; do
+      if [[ "$(cat "$i/address")" == "$mac" ]]; then
+        basename "$i"
+        break
+      fi
+    done)
+
+    if [[ -n "$iface" ]]; then
+      echo "Setting MTU $MTU_DEFAULT on interface $iface (MAC $mac)"
+      sudo ip link set dev "$iface" mtu $MTU_DEFAULT up
+    else
+      echo "No interface found for MAC $mac"
+    fi
+  done
+done < "/opt/hdev/cli/devices_network"
+echo ""
 
 #create devices_acap_fpga_coyote
 sudo $CLI_PATH/common/get_devices_acap_fpga_coyote


### PR DESCRIPTION
Removes dependency on NetworkManager and only uses core linux network features suchas sysfs and the ip command.